### PR TITLE
ci: update commit message check rules

### DIFF
--- a/.github/workflows/commit_message.yml
+++ b/.github/workflows/commit_message.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(doc|fix|ci|core|module|feat):\s+\S+'
+          pattern: '^(meow|docs|fix|ci|core|module|feat|style|refactor|test|ci|build|chore|perf):\s+\S+'
           flags: 'gm'
-          error: 'Your first line has to contain a commit type in [module/feat/fix/doc/style/refactor/test/chore/perf/ci/build].'
+          error: 'Your first line has to contain a commit type in [meow/module/feat/fix/docs/style/refactor/test/chore/perf/ci/build].'


### PR DESCRIPTION
Now accept tag `meow` and `build`, change `doc` to `docs`