### PR TITLE
fix: Fixed a wrong message when the user starts a new project

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function getInformation(isDefault) {
 			);
 			console.log(
 				warning(
-					'You should make sure the dependencies are well organized. If you want to use dependencies (latest version) besides @mc/server.'
+					'You should make sure the dependencies are well organized if you want to use dependencies (latest version) besides @mc/server.'
 				)
 			);
 


### PR DESCRIPTION
使用`serein i`初始化项目并设置依赖项时提示消息存在错误：条件从句被拆分为了两句话。